### PR TITLE
Add coming soon pages for new sidebar sections

### DIFF
--- a/src/app/[variants]/(main)/_layout/Desktop/SideBar/TopActions.tsx
+++ b/src/app/[variants]/(main)/_layout/Desktop/SideBar/TopActions.tsx
@@ -114,42 +114,18 @@ const TopActions = memo<TopActionProps>(({ tab, isPinned }) => {
           />
         </Link>
       )}
-      <Link aria-label={'Stucks'} href={'/image'}>
-        <ActionIcon
-          active={isImageActive}
-          icon={HeartCrack}
-          size={ICON_SIZE}
-          title={'Stucks'}
-          tooltipProps={{ placement: 'right' }}
-        />
+      <Link aria-label={'Stucks'} href={'/stucks'}>
+        <ActionIcon icon={HeartCrack} size={ICON_SIZE} title={'Stucks'} tooltipProps={{ placement: 'right' }} />
       </Link>
-      <Link aria-label={t('tab.aiImage')} href={'/image'}>
-        <ActionIcon
-          active={isImageActive}
-          icon={Orbit}
-          size={ICON_SIZE}
-          title={'Economy'}
-          tooltipProps={{ placement: 'right' }}
-        />
+      <Link aria-label={'Economy'} href={'/economy'}>
+        <ActionIcon icon={Orbit} size={ICON_SIZE} title={'Economy'} tooltipProps={{ placement: 'right' }} />
       </Link>
 
-      <Link aria-label={t('tab.aiImage')} href={'/image'}>
-        <ActionIcon
-          active={isImageActive}
-          icon={User}
-          size={ICON_SIZE}
-          title={'Contacts'}
-          tooltipProps={{ placement: 'right' }}
-        />
+      <Link aria-label={'Contacts'} href={'/contacts'}>
+        <ActionIcon icon={User} size={ICON_SIZE} title={'Contacts'} tooltipProps={{ placement: 'right' }} />
       </Link>
-      <Link aria-label={t('tab.aiImage')} href={'/image'}>
-        <ActionIcon
-          active={isImageActive}
-          icon={MessagesSquare}
-          size={ICON_SIZE}
-          title={'Agentic Chats'}
-          tooltipProps={{ placement: 'right' }}
-        />
+      <Link aria-label={'Agentic Chats'} href={'/agentic-chats'}>
+        <ActionIcon icon={MessagesSquare} size={ICON_SIZE} title={'Agentic Chats'} tooltipProps={{ placement: 'right' }} />
       </Link>
     </Flexbox>
   );

--- a/src/app/[variants]/(main)/agentic-chats/page.tsx
+++ b/src/app/[variants]/(main)/agentic-chats/page.tsx
@@ -1,0 +1,5 @@
+import ComingSoon from '@/components/ComingSoon';
+
+export default function Page() {
+  return <ComingSoon />;
+}

--- a/src/app/[variants]/(main)/contacts/page.tsx
+++ b/src/app/[variants]/(main)/contacts/page.tsx
@@ -1,0 +1,5 @@
+import ComingSoon from '@/components/ComingSoon';
+
+export default function Page() {
+  return <ComingSoon />;
+}

--- a/src/app/[variants]/(main)/economy/page.tsx
+++ b/src/app/[variants]/(main)/economy/page.tsx
@@ -1,0 +1,5 @@
+import ComingSoon from '@/components/ComingSoon';
+
+export default function Page() {
+  return <ComingSoon />;
+}

--- a/src/app/[variants]/(main)/stucks/page.tsx
+++ b/src/app/[variants]/(main)/stucks/page.tsx
@@ -1,0 +1,5 @@
+import ComingSoon from '@/components/ComingSoon';
+
+export default function Page() {
+  return <ComingSoon />;
+}

--- a/src/components/ComingSoon/index.tsx
+++ b/src/components/ComingSoon/index.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { FluentEmoji } from '@lobehub/ui';
+import { Center, Flexbox } from 'react-layout-kit';
+import { memo } from 'react';
+
+const ComingSoon = memo(() => (
+  <Center height={'100%'} width={'100%'}>
+    <Flexbox align={'center'} gap={12}>
+      <FluentEmoji emoji={'🚧'} size={64} />
+      <h2>Coming Soon!</h2>
+    </Flexbox>
+  </Center>
+));
+
+ComingSoon.displayName = 'ComingSoon';
+
+export default ComingSoon;


### PR DESCRIPTION
## Summary
- show Coming Soon placeholder for Stucks, Economy, Contacts and Agentic Chats
- link the desktop sidebar buttons to these pages

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint:ts` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6880412b1518832b9ab3ba9a732644a9